### PR TITLE
Add default scraper for flights and hotels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,23 @@ SmartFamilyTravelScout is an AI-powered family travel deal finder that scrapes f
 
 **Tech Stack**: Python 3.11+, FastAPI, PostgreSQL, Redis, Celery, Playwright, SQLAlchemy (async), Anthropic Claude API
 
+## Quick Start (No API Key Needed!)
+
+You can start scraping flights immediately using the default scrapers (Skyscanner, Ryanair, WizzAir) without any API keys:
+
+```bash
+# Quick scrape with all free scrapers
+poetry run scout scrape --origin MUC --destination BCN
+
+# Use a specific scraper
+poetry run scout scrape --origin VIE --destination LIS --scraper skyscanner
+
+# Test individual scrapers
+poetry run scout test-scraper ryanair --origin MUC --dest PRG
+```
+
+The default scrapers work out of the box - no configuration needed!
+
 ## Development Commands
 
 ### Setup & Installation
@@ -40,9 +57,15 @@ docker-compose up -d
 
 # CLI commands (using 'scout')
 poetry run scout health          # Check system health
+poetry run scout scrape --origin MUC --destination LIS  # Quick scrape (no API key needed!)
 poetry run scout run             # Run full pipeline
 poetry run scout deals           # View top deals
 poetry run scout stats           # Show statistics
+
+# Quick start with default (free) scrapers - NO API KEY NEEDED:
+poetry run scout scrape --origin MUC --destination BCN
+poetry run scout scrape --origin VIE --destination LIS --scraper skyscanner
+poetry run scout test-scraper skyscanner --origin MUC --dest PRG
 ```
 
 ### Testing
@@ -115,13 +138,21 @@ poetry run mypy app/
 ### Core Components
 
 **Scrapers** (`app/scrapers/`): Web scrapers for multiple data sources
-- `kiwi_scraper.py`: Kiwi.com API client (flight aggregator)
-- `skyscanner_scraper.py`: Skyscanner web scraper (Playwright)
-- `ryanair_scraper.py`: Ryanair web scraper
-- `wizzair_scraper.py`: WizzAir API scraper
+
+**Default Scrapers (NO API KEY NEEDED):**
+- `skyscanner_scraper.py`: Skyscanner web scraper (Playwright) ✓ FREE
+- `ryanair_scraper.py`: Ryanair web scraper (Playwright) ✓ FREE
+- `wizzair_scraper.py`: WizzAir API scraper (unofficial API) ✓ FREE
+
+**API-Key Scrapers:**
+- `kiwi_scraper.py`: Kiwi.com API client (requires KIWI_API_KEY - 100 calls/month free tier)
+- `eventbrite_scraper.py`: Eventbrite API client (requires EVENTBRITE_API_KEY)
+
+**Accommodation Scrapers:**
 - `booking_scraper.py`: Booking.com scraper (accommodations)
 - `airbnb_scraper.py`: Airbnb scraper (accommodations)
-- `eventbrite_scraper.py`: Eventbrite API client (events)
+
+**Tourism Scrapers:**
 - Tourism scrapers: Barcelona, Prague, Lisbon city events
 
 **Orchestration** (`app/orchestration/`): Coordinates multiple scrapers and data sources

--- a/README.md
+++ b/README.md
@@ -8,12 +8,40 @@ SmartFamilyTravelScout combines web scraping, AI-powered analysis, and intellige
 
 ### Key Features
 
+- **No API Key Needed to Start**: Use default scrapers (Skyscanner, Ryanair, WizzAir) without configuration! 🚀
 - **Intelligent Flight Discovery**: Scrapes multiple airlines (Ryanair, Wizz Air, etc.) and aggregators (Kiwi, Skyscanner)
 - **Accommodation Matching**: Finds family-friendly accommodations (Booking.com, Airbnb)
 - **Event Integration**: Discovers local family events and activities (Eventbrite)
 - **AI-Powered Scoring**: Uses Claude AI to evaluate deal quality and family-friendliness
 - **Smart Orchestration**: Celery-based task scheduling for automated deal discovery
 - **Price Tracking**: Monitor prices over time and get alerts for the best deals
+
+### 🎯 Quick Start - No Setup Required!
+
+Want to start immediately without any API keys? Use the default scrapers:
+
+```bash
+# Install dependencies
+poetry install
+
+# Scrape flights using free scrapers (no API key needed!)
+poetry run scout scrape --origin MUC --destination BCN
+
+# Use a specific scraper
+poetry run scout scrape --origin VIE --destination LIS --scraper skyscanner
+
+# Test individual scrapers
+poetry run scout test-scraper ryanair --origin MUC --dest PRG
+```
+
+**Default (free) scrapers:**
+- ✅ **Skyscanner** - Web scraper (Playwright)
+- ✅ **Ryanair** - Web scraper (Playwright)
+- ✅ **WizzAir** - API scraper (no auth)
+
+**Optional scrapers (require API keys):**
+- Kiwi.com - Requires `KIWI_API_KEY` (100 calls/month free)
+- Eventbrite - Requires `EVENTBRITE_API_KEY`
 
 ## Technology Stack
 


### PR DESCRIPTION
Added support for default scrapers (Skyscanner, Ryanair, WizzAir) that work without API keys, making it easy to start using the application immediately.

Changes:
- Added scraper enable/disable flags in config.py
- Added get_available_scrapers() method to auto-detect available scrapers
- Updated FlightOrchestrator to only use enabled scrapers
- Added new 'scout scrape' CLI command for quick scraping with free scrapers
- Updated documentation (README.md, CLAUDE.md) to highlight default scrapers
- FlightOrchestrator now respects scraper configuration and skips those requiring missing API keys

Benefits:
- Users can start immediately without configuring API keys
- Clear separation between free and API-key scrapers
- Better error handling when API keys are missing
- Simplified onboarding experience

Usage:
  scout scrape --origin MUC --destination BCN scout scrape --origin VIE --destination LIS --scraper skyscanner scout test-scraper ryanair --origin MUC --dest PRG