### PR TITLE
Add anti-ban measures to WizzAir scraper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,15 @@ SCRAPER_MAX_RETRIES=3
 SCRAPER_TIMEOUT=30
 SCRAPER_USER_AGENT=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
 
+# WizzAir anti-ban settings
+# Set a residential/mobile proxy here if you keep getting blocked (datacenter IPs are filtered).
+# Format: http://user:pass@host:port  or  http://host:port
+# WIZZAIR_PROXY_URL=
+WIZZAIR_API_VERSION=27.4.0
+WIZZAIR_WARMUP_ENABLED=true
+WIZZAIR_MIN_DELAY_SECONDS=3
+WIZZAIR_MAX_DELAY_SECONDS=7
+
 # Price Thresholds (in EUR)
 MAX_FLIGHT_PRICE_PER_PERSON=200
 MAX_ACCOMMODATION_PRICE_PER_NIGHT=150

--- a/app/config.py
+++ b/app/config.py
@@ -100,6 +100,30 @@ class Settings(BaseSettings):
         le=1.0,
     )
 
+    # WizzAir-specific anti-ban settings
+    wizzair_proxy_url: Optional[str] = Field(
+        default=None,
+        description="HTTP(S) proxy URL for WizzAir requests (e.g. http://user:pass@host:port). When set, used for both warm-up and API calls.",
+    )
+    wizzair_api_version: str = Field(
+        default="27.4.0",
+        description="WizzAir internal API version path segment. Bump if scraper starts returning 404.",
+    )
+    wizzair_warmup_enabled: bool = Field(
+        default=True,
+        description="Hit wizzair.com once per scrape to collect Cloudflare/session cookies before calling the JSON API.",
+    )
+    wizzair_min_delay_seconds: float = Field(
+        default=3.0,
+        description="Minimum seconds between WizzAir API calls (jittered up to wizzair_max_delay_seconds).",
+        ge=0.0,
+    )
+    wizzair_max_delay_seconds: float = Field(
+        default=7.0,
+        description="Maximum seconds between WizzAir API calls.",
+        ge=0.0,
+    )
+
     # Price Thresholds (in EUR)
     max_flight_price_per_person: float = Field(
         default=200.0, description="Maximum flight price per person in EUR"

--- a/app/scrapers/wizzair_scraper.py
+++ b/app/scrapers/wizzair_scraper.py
@@ -11,7 +11,10 @@ inspect the network traffic on wizzair.com using browser DevTools to find the
 updated API endpoint and request format.
 """
 
+import asyncio
 import logging
+import random
+import time as _time
 from datetime import date, datetime, time
 from typing import Any, Dict, List, Optional
 
@@ -19,6 +22,14 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+try:  # HTTP/2 is optional but improves TLS fingerprint match with real browsers.
+    import h2  # noqa: F401
+
+    _HTTP2_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _HTTP2_AVAILABLE = False
+
+from app.config import settings
 from app.models.airport import Airport
 from app.models.flight import Flight
 from app.utils.retry import api_retry
@@ -38,6 +49,17 @@ class WizzAirRateLimitError(Exception):
     pass
 
 
+_USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15",
+]
+
+
+_last_request_time: float = 0.0
+
+
 class WizzAirScraper:
     """
     Scraper for WizzAir flights using their unofficial API.
@@ -46,30 +68,104 @@ class WizzAirScraper:
     particularly Moldova (Chisinau).
     """
 
-    # WizzAir API endpoint (the * is a wildcard for API version)
-    BASE_URL = "https://be.wizzair.com/*/Api/search/search"
+    BASE_URL_TEMPLATE = "https://be.wizzair.com/{version}/Api/search/search"
+    WARMUP_URL = "https://wizzair.com/en-gb"
 
-    # User agent to mimic browser requests
-    USER_AGENT = (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    )
-
-    def __init__(self, timeout: int = 30) -> None:
+    def __init__(
+        self,
+        timeout: int = 30,
+        proxy_url: Optional[str] = None,
+        api_version: Optional[str] = None,
+        warmup: Optional[bool] = None,
+        min_delay_seconds: Optional[float] = None,
+        max_delay_seconds: Optional[float] = None,
+    ) -> None:
         """
         Initialize the WizzAir scraper.
 
         Args:
             timeout: HTTP request timeout in seconds (default: 30)
+            proxy_url: HTTP(S) proxy URL. Falls back to ``settings.wizzair_proxy_url``.
+            api_version: WizzAir internal API version segment. Falls back to ``settings.wizzair_api_version``.
+            warmup: When True, GET ``wizzair.com`` once per search to collect cookies before the API call.
+                Falls back to ``settings.wizzair_warmup_enabled``.
+            min_delay_seconds: Minimum jittered delay between calls (defaults to settings).
+            max_delay_seconds: Maximum jittered delay between calls (defaults to settings).
         """
         self.timeout = timeout
-        self.headers = {
-            "User-Agent": self.USER_AGENT,
+        self.proxy_url = proxy_url if proxy_url is not None else settings.wizzair_proxy_url
+        self.api_version = api_version or settings.wizzair_api_version
+        self.warmup = settings.wizzair_warmup_enabled if warmup is None else warmup
+        self.min_delay = (
+            settings.wizzair_min_delay_seconds
+            if min_delay_seconds is None
+            else min_delay_seconds
+        )
+        self.max_delay = (
+            settings.wizzair_max_delay_seconds
+            if max_delay_seconds is None
+            else max_delay_seconds
+        )
+        self.user_agent = random.choice(_USER_AGENTS)
+
+    @property
+    def headers(self) -> Dict[str, str]:
+        """Browser-mimicking headers for the JSON API call."""
+        return {
+            "User-Agent": self.user_agent,
             "Content-Type": "application/json",
-            "Accept": "application/json",
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "en-US,en;q=0.9",
             "Origin": "https://wizzair.com",
             "Referer": "https://wizzair.com/",
+            "X-Requested-With": "XMLHttpRequest",
+            "Sec-Fetch-Site": "same-site",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Dest": "empty",
         }
+
+    @property
+    def warmup_headers(self) -> Dict[str, str]:
+        """Headers used for the homepage warm-up request."""
+        return {
+            "User-Agent": self.user_agent,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Sec-Fetch-Site": "none",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Dest": "document",
+            "Upgrade-Insecure-Requests": "1",
+        }
+
+    @property
+    def base_url(self) -> str:
+        return self.BASE_URL_TEMPLATE.format(version=self.api_version)
+
+    async def _respectful_delay(self) -> None:
+        """Jittered delay between API calls to avoid rate-limit / WAF tripping."""
+        if self.max_delay <= 0:
+            return
+
+        global _last_request_time
+        now = _time.time()
+        since_last = now - _last_request_time
+        if since_last < self.min_delay:
+            await asyncio.sleep(self.min_delay - since_last)
+        if self.max_delay > self.min_delay:
+            await asyncio.sleep(random.uniform(0, self.max_delay - self.min_delay))
+        _last_request_time = _time.time()
+
+    async def _warmup(self, client: httpx.AsyncClient) -> None:
+        """Hit the WizzAir homepage so the client picks up Cloudflare/session cookies."""
+        try:
+            response = await client.get(self.WARMUP_URL, headers=self.warmup_headers)
+            logger.debug(
+                f"WizzAir warm-up: status={response.status_code}, "
+                f"cookies={len(client.cookies)}"
+            )
+        except httpx.HTTPError as e:
+            # Warm-up is best-effort — if it fails, the API call will still try.
+            logger.warning(f"WizzAir warm-up failed (continuing anyway): {e}")
 
     def _build_payload(
         self,
@@ -169,10 +265,24 @@ class WizzAirScraper:
             f"departure: {departure_date}, return: {return_date}"
         )
 
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
+        await self._respectful_delay()
+
+        client_kwargs: Dict[str, Any] = {
+            "timeout": self.timeout,
+            "follow_redirects": True,
+        }
+        if _HTTP2_AVAILABLE:
+            client_kwargs["http2"] = True
+        if self.proxy_url:
+            client_kwargs["proxies"] = self.proxy_url
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
             try:
+                if self.warmup:
+                    await self._warmup(client)
+
                 response = await client.post(
-                    self.BASE_URL, headers=self.headers, json=payload
+                    self.base_url, headers=self.headers, json=payload
                 )
 
                 # Check for rate limiting
@@ -180,6 +290,20 @@ class WizzAirScraper:
                     logger.error("WizzAir API rate limit exceeded")
                     raise WizzAirRateLimitError(
                         "Rate limit exceeded. Please wait 60 seconds before retrying."
+                    )
+
+                # Cloudflare / WAF ban — usually means the IP needs to rotate
+                # or the session lacks the cf_clearance cookie.
+                if response.status_code in (401, 403):
+                    logger.error(
+                        f"WizzAir API blocked: status={response.status_code}. "
+                        f"Likely IP/WAF ban — consider rotating proxy "
+                        f"(set WIZZAIR_PROXY_URL) or bumping wizzair_api_version."
+                    )
+                    raise WizzAirAPIError(
+                        f"WizzAir blocked the request (HTTP {response.status_code}). "
+                        f"This is typically a Cloudflare/IP block — "
+                        f"configure WIZZAIR_PROXY_URL or update the API version."
                     )
 
                 # Check for other HTTP errors

--- a/tests/unit/test_wizzair_scraper.py
+++ b/tests/unit/test_wizzair_scraper.py
@@ -25,8 +25,13 @@ from app.scrapers.wizzair_scraper import (
 
 @pytest.fixture
 def scraper() -> WizzAirScraper:
-    """Create a WizzAir scraper instance."""
-    return WizzAirScraper(timeout=30)
+    """Create a WizzAir scraper instance with warm-up and delays disabled for unit tests."""
+    return WizzAirScraper(
+        timeout=30,
+        warmup=False,
+        min_delay_seconds=0,
+        max_delay_seconds=0,
+    )
 
 
 @pytest.fixture
@@ -462,6 +467,12 @@ class TestWizzAirScraper:
         with patch("httpx.AsyncClient.post", return_value=mock_response), patch(
             "app.scrapers.wizzair_scraper.WizzAirScraper._get_airport_by_iata",
             return_value=mock_airport,
+        ), patch(
+            "app.scrapers.wizzair_scraper.WizzAirScraper._warmup",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "app.scrapers.wizzair_scraper.WizzAirScraper._respectful_delay",
+            new=AsyncMock(return_value=None),
         ):
             flights = await scrape_wizzair_flights(
                 db=mock_db_session,


### PR DESCRIPTION
## Summary

Enhance the WizzAir scraper with anti-ban and anti-WAF measures to improve reliability and reduce blocking. This includes proxy support, configurable delays, homepage warm-up requests, HTTP/2 support, and better error handling for Cloudflare blocks.

## Key Changes

- **Proxy Support**: Added `wizzair_proxy_url` configuration to route requests through residential/mobile proxies, helping avoid datacenter IP blocks
- **Configurable Rate Limiting**: Implemented jittered delays between API calls with `wizzair_min_delay_seconds` and `wizzair_max_delay_seconds` settings (defaults: 3-7 seconds)
- **Homepage Warm-up**: Added optional warm-up request to `wizzair.com` before API calls to collect Cloudflare/session cookies, controlled by `wizzair_warmup_enabled`
- **HTTP/2 Support**: Automatically enables HTTP/2 when the `h2` library is available to improve TLS fingerprint matching with real browsers
- **User-Agent Rotation**: Randomly selects from a pool of realistic browser user agents instead of using a static one
- **API Version Configuration**: Made API version path segment configurable via `wizzair_api_version` to allow quick updates when WizzAir changes their API
- **Enhanced Headers**: Added more realistic browser headers (Accept-Language, Sec-Fetch-*, X-Requested-With) to better mimic legitimate browser traffic
- **Better Error Handling**: Added specific detection and logging for HTTP 401/403 responses (Cloudflare/WAF blocks) with actionable guidance

## Configuration

New environment variables in `.env.example`:
- `WIZZAIR_PROXY_URL`: Optional HTTP(S) proxy URL
- `WIZZAIR_API_VERSION`: API version segment (default: 27.4.0)
- `WIZZAIR_WARMUP_ENABLED`: Enable homepage warm-up (default: true)
- `WIZZAIR_MIN_DELAY_SECONDS`: Minimum delay between calls (default: 3.0)
- `WIZZAIR_MAX_DELAY_SECONDS`: Maximum delay between calls (default: 7.0)

## Testing

Updated unit tests to disable warm-up and delays for faster test execution, and added mocks for the new `_warmup()` and `_respectful_delay()` methods.

https://claude.ai/code/session_018FqofpSVVPeMRS5tCdKs4f